### PR TITLE
SchedleTask support adding linked_list by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/arceos-org/scheduler"
 documentation = "https://arceos-org.github.io/scheduler"
 
 [dependencies]
-linked_list_r4l = { version = "0.2.0" }
+linked_list_r4l = { git = "https://github.com/arceos-org/linked_list_r4l.git", branch = "guoweikang/add_push_front" }

--- a/src/cfs.rs
+++ b/src/cfs.rs
@@ -1,6 +1,7 @@
 use alloc::{collections::BTreeMap, sync::Arc};
 use core::ops::Deref;
 use core::sync::atomic::{AtomicIsize, Ordering};
+use linked_list_r4l::{GetLinks, Links};
 
 use crate::BaseScheduler;
 
@@ -11,6 +12,7 @@ pub struct CFSTask<T> {
     delta: AtomicIsize,
     nice: AtomicIsize,
     id: AtomicIsize,
+    links: Links<Self>,
 }
 
 // https://elixir.bootlin.com/linux/latest/source/include/linux/sched/prio.h
@@ -28,6 +30,14 @@ const NICE2WEIGHT_NEG: [isize; NICE_RANGE_NEG + 1] = [
     29154, 36291, 46273, 56483, 71755, 88761,
 ];
 
+impl<T> GetLinks for CFSTask<T> {
+    type EntryType = Self;
+
+    fn get_links(t: &Self) -> &Links<Self> {
+        &t.links
+    }
+}
+
 impl<T> CFSTask<T> {
     /// new with default values
     pub const fn new(inner: T) -> Self {
@@ -37,6 +47,7 @@ impl<T> CFSTask<T> {
             delta: AtomicIsize::new(0_isize),
             nice: AtomicIsize::new(0_isize),
             id: AtomicIsize::new(0_isize),
+            links: Links::new(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub use round_robin::{RRScheduler, RRTask};
 /// sleep, it should be removed from the scheduler.
 pub trait BaseScheduler {
     /// Type of scheduled entities. Often a task struct.
-    type SchedItem;
+    type SchedItem: linked_list_r4l::GetLinks;
 
     /// Initializes the scheduler.
     fn init(&mut self);


### PR DESCRIPTION
--------
In cfs and fifo scheduling, task is already a ListNode. In addition, in most scheduling scenarios, tasks will be added to the linked list (wait queue) as list nodes. Therefore, it is decided to make Node support as the default behavior of Task.