### PR TITLE
cfs: Don't re-schedule when ready_queue is empty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scheduler"
-version = "0.3.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Yuekai Jia <equation618@gmail.com>"]
 description = "Various scheduler algorithms in a unified interface"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scheduler"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Yuekai Jia <equation618@gmail.com>"]
 description = "Various scheduler algorithms in a unified interface"

--- a/src/cfs.rs
+++ b/src/cfs.rs
@@ -175,6 +175,9 @@ impl<T> BaseScheduler for CFScheduler<T> {
 
     fn task_tick(&mut self, current: &Self::SchedItem) -> bool {
         current.task_tick();
+        if self.ready_queue.is_empty() {
+            return false;
+        }
         self.min_vruntime.is_none()
             || current.get_vruntime() > self.min_vruntime.as_mut().unwrap().load(Ordering::Acquire)
     }


### PR DESCRIPTION
When ready-queue is empty, re-schedule makes no sense.
Please refer to: https://github.com/orgs/rcore-os/discussions/53#discussioncomment-13264939