### PR TITLE
Use linked list in `RRScheduler`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ documentation = "https://docs.rs/axsched"
 rust-version = "1.76"
 
 [dependencies]
-linked_list_r4l = "0.2"
+linked_list_r4l = "0.3"

--- a/src/round_robin.rs
+++ b/src/round_robin.rs
@@ -1,6 +1,8 @@
-use alloc::{collections::VecDeque, sync::Arc};
+use alloc::sync::Arc;
 use core::ops::Deref;
 use core::sync::atomic::{AtomicIsize, Ordering};
+
+use linked_list_r4l::{GetLinks, Links, List};
 
 use crate::BaseScheduler;
 
@@ -10,6 +12,7 @@ use crate::BaseScheduler;
 pub struct RRTask<T, const MAX_TIME_SLICE: usize> {
     inner: T,
     time_slice: AtomicIsize,
+    links: Links<Self>,
 }
 
 impl<T, const S: usize> RRTask<T, S> {
@@ -18,6 +21,7 @@ impl<T, const S: usize> RRTask<T, S> {
         Self {
             inner,
             time_slice: AtomicIsize::new(S as isize),
+            links: Links::new(),
         }
     }
 
@@ -32,6 +36,14 @@ impl<T, const S: usize> RRTask<T, S> {
     /// Returns a reference to the inner task struct.
     pub const fn inner(&self) -> &T {
         &self.inner
+    }
+}
+
+impl<T, const MAX_TIME_SLICE: usize> GetLinks for RRTask<T, MAX_TIME_SLICE> {
+    type EntryType = Self;
+
+    fn get_links(data: &Self::EntryType) -> &Links<Self::EntryType> {
+        &data.links
     }
 }
 
@@ -50,20 +62,19 @@ impl<T, const S: usize> Deref for RRTask<T, S> {
 /// task's time slice counter reaches zero, the task is preempted and needs to
 /// be rescheduled.
 ///
-/// Unlike [`FifoScheduler`], it uses [`VecDeque`] as the ready queue. So it may
-/// take O(n) time to remove a task from the ready queue.
+/// It internally uses a linked list as the ready queue.
 ///
 /// [Round-Robin]: https://en.wikipedia.org/wiki/Round-robin_scheduling
 /// [`FifoScheduler`]: crate::FifoScheduler
 pub struct RRScheduler<T, const MAX_TIME_SLICE: usize> {
-    ready_queue: VecDeque<Arc<RRTask<T, MAX_TIME_SLICE>>>,
+    ready_queue: List<Arc<RRTask<T, MAX_TIME_SLICE>>>,
 }
 
 impl<T, const S: usize> RRScheduler<T, S> {
     /// Creates a new empty [`RRScheduler`].
     pub const fn new() -> Self {
         Self {
-            ready_queue: VecDeque::new(),
+            ready_queue: List::new(),
         }
     }
     /// get the name of scheduler
@@ -82,11 +93,7 @@ impl<T, const S: usize> BaseScheduler for RRScheduler<T, S> {
     }
 
     fn remove_task(&mut self, task: &Self::SchedItem) -> Option<Self::SchedItem> {
-        // TODO: more efficient
-        self.ready_queue
-            .iter()
-            .position(|t| Arc::ptr_eq(t, task))
-            .and_then(|idx| self.ready_queue.remove(idx))
+        unsafe { self.ready_queue.remove(task) }
     }
 
     fn pick_next_task(&mut self) -> Option<Self::SchedItem> {


### PR DESCRIPTION
## Description

The current round-robin scheduler uses a `VecDeque` to store ready tasks, which is inefficient because all required operations can be performed in constant time using a linked list. This PR replaces `VecDeque` with `linked_list_r4l::List`, thereby enhancing the scheduler's theoretical performance.

## Backward compatibility

The public interface remains unchanged.
